### PR TITLE
feat: add support for specifying platform targets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: Github token to use
     required: true
     default: null
+  platforms:
+    description: List of target platforms for build (as specified by docker/build-push-action)
+    required: false
 
 runs:
   using: composite
@@ -61,6 +64,7 @@ runs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        platforms: ${{ inputs.platforms }}
         push: true
         tags: ${{ inputs.image }}:latest, ${{ inputs.image }}:${{ steps.semantic-release.outputs.new_release_version }}
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ inputs:
   platforms:
     description: List of target platforms for build (as specified by docker/build-push-action)
     required: false
+    default: null
 
 runs:
   using: composite


### PR DESCRIPTION
Resolved #3 

## Description
Adds option to pass `plattforms` to `docker/build-push-action` so that its possible to use the github action to build docker images for multiple plattforms. 

E.g you could pass `platforms: linux/amd64,linux/arm64` 

